### PR TITLE
Load assets through Content API so they can be patched

### DIFF
--- a/ShopTileFramework/ShopTileFramework.csproj
+++ b/ShopTileFramework/ShopTileFramework.csproj
@@ -5,8 +5,6 @@
     <RootNamespace>ShopTileFramework</RootNamespace>
     <Version>1.0.0</Version>
     <TargetFramework>net452</TargetFramework>
-    <Platforms>x86</Platforms>
-    <PlatformTarget>x86</PlatformTarget>
 
     <EnableHarmony>true</EnableHarmony>
   </PropertyGroup>

--- a/ShopTileFramework/src/API/STFAPI.cs
+++ b/ShopTileFramework/src/API/STFAPI.cs
@@ -3,7 +3,7 @@ using ShopTileFramework.Shop;
 using StardewValley;
 using System;
 using System.Collections.Generic;
-using StardewModdingAPI;
+using StardewModdingAPI.Utilities;
 
 namespace ShopTileFramework.API
 {
@@ -41,7 +41,7 @@ namespace ShopTileFramework.API
         public bool OpenItemShop(string shopName)
         {
             //opens up the shop of ShopName in-game
-            Dictionary<string, ItemShop> itemShops = Game1.content.Load<Dictionary<string, ItemShop>>("Mods/ShopTileFramework/ItemShops");
+            Dictionary<string, ItemShop> itemShops = Game1.content.Load<Dictionary<string, ItemShop>>(PathUtilities.NormalizePath("Mods/ShopTileFramework/ItemShops"));
             itemShops.TryGetValue(shopName, out var shop);
             if (shop == null)
             {
@@ -60,7 +60,7 @@ namespace ShopTileFramework.API
         public bool OpenAnimalShop(string shopName)
         {
             //opens up the shop of ShopName in-game
-            Dictionary<string, AnimalShop> animalShops = Game1.content.Load<Dictionary<string, AnimalShop>>("Mods/ShopTileFramework/AnimalShops");
+            Dictionary<string, AnimalShop> animalShops = Game1.content.Load<Dictionary<string, AnimalShop>>(PathUtilities.NormalizePath("Mods/ShopTileFramework/AnimalShops"));
             animalShops.TryGetValue(shopName, out var shop);
             if (shop == null)
             {
@@ -79,7 +79,7 @@ namespace ShopTileFramework.API
         public bool ResetShopStock(string shopName)
         {
             //resets the stock of the given ShopName
-            Dictionary<string, ItemShop> itemShops = Game1.content.Load<Dictionary<string, ItemShop>>("Mods/ShopTileFramework/ItemShops");
+            Dictionary<string, ItemShop> itemShops = Game1.content.Load<Dictionary<string, ItemShop>>(PathUtilities.NormalizePath("Mods/ShopTileFramework/ItemShops"));
             itemShops.TryGetValue(shopName, out var shop);
             if (shop == null)
             {
@@ -98,7 +98,7 @@ namespace ShopTileFramework.API
         public Dictionary<ISalable, int[]> GetItemPriceAndStock(string shopName)
         {
             //gets the ItemStockAndPrice of the given ShopName
-            Dictionary<string, ItemShop> itemShops = Game1.content.Load<Dictionary<string, ItemShop>>("Mods/ShopTileFramework/ItemShops");
+            Dictionary<string, ItemShop> itemShops = Game1.content.Load<Dictionary<string, ItemShop>>(PathUtilities.NormalizePath("Mods/ShopTileFramework/ItemShops"));
             itemShops.TryGetValue(shopName, out var shop);
             if (shop == null)
             {

--- a/ShopTileFramework/src/API/STFAPI.cs
+++ b/ShopTileFramework/src/API/STFAPI.cs
@@ -29,7 +29,7 @@ namespace ShopTileFramework.API
                 return false;
             }
 
-            ShopManager.RegisterShops(newShopModel, temp);
+            ModEntry.ShopManager.RegisterShops(newShopModel, temp);
             return true;
         }
 
@@ -41,7 +41,7 @@ namespace ShopTileFramework.API
         public bool OpenItemShop(string shopName)
         {
             //opens up the shop of ShopName in-game
-            Dictionary<string, ItemShop> itemShops = ModEntry.helper.Content.Load<Dictionary<string, ItemShop>>("Mods/ShopTileFramework/ItemShops", ContentSource.GameContent);
+            Dictionary<string, ItemShop> itemShops = Game1.content.Load<Dictionary<string, ItemShop>>("Mods/ShopTileFramework/ItemShops");
             itemShops.TryGetValue(shopName, out var shop);
             if (shop == null)
             {
@@ -60,7 +60,7 @@ namespace ShopTileFramework.API
         public bool OpenAnimalShop(string shopName)
         {
             //opens up the shop of ShopName in-game
-            Dictionary<string, AnimalShop> animalShops = ModEntry.helper.Content.Load<Dictionary<string, AnimalShop>>("Mods/ShopTileFramework/AnimalShops", ContentSource.GameContent);
+            Dictionary<string, AnimalShop> animalShops = Game1.content.Load<Dictionary<string, AnimalShop>>("Mods/ShopTileFramework/AnimalShops");
             animalShops.TryGetValue(shopName, out var shop);
             if (shop == null)
             {
@@ -79,7 +79,7 @@ namespace ShopTileFramework.API
         public bool ResetShopStock(string shopName)
         {
             //resets the stock of the given ShopName
-            Dictionary<string, ItemShop> itemShops = ModEntry.helper.Content.Load<Dictionary<string, ItemShop>>("Mods/ShopTileFramework/ItemShops", ContentSource.GameContent);
+            Dictionary<string, ItemShop> itemShops = Game1.content.Load<Dictionary<string, ItemShop>>("Mods/ShopTileFramework/ItemShops");
             itemShops.TryGetValue(shopName, out var shop);
             if (shop == null)
             {
@@ -98,7 +98,7 @@ namespace ShopTileFramework.API
         public Dictionary<ISalable, int[]> GetItemPriceAndStock(string shopName)
         {
             //gets the ItemStockAndPrice of the given ShopName
-            Dictionary<string, ItemShop> itemShops = ModEntry.helper.Content.Load<Dictionary<string, ItemShop>>("Mods/ShopTileFramework/ItemShops", ContentSource.GameContent);
+            Dictionary<string, ItemShop> itemShops = Game1.content.Load<Dictionary<string, ItemShop>>("Mods/ShopTileFramework/ItemShops");
             itemShops.TryGetValue(shopName, out var shop);
             if (shop == null)
             {

--- a/ShopTileFramework/src/API/STFAPI.cs
+++ b/ShopTileFramework/src/API/STFAPI.cs
@@ -3,6 +3,7 @@ using ShopTileFramework.Shop;
 using StardewValley;
 using System;
 using System.Collections.Generic;
+using StardewModdingAPI;
 
 namespace ShopTileFramework.API
 {
@@ -40,7 +41,8 @@ namespace ShopTileFramework.API
         public bool OpenItemShop(string shopName)
         {
             //opens up the shop of ShopName in-game
-            ShopManager.ItemShops.TryGetValue(shopName, out var shop);
+            Dictionary<string, ItemShop> itemShops = ModEntry.helper.Content.Load<Dictionary<string, ItemShop>>("Mods/ShopTileFramework/ItemShops", ContentSource.GameContent);
+            itemShops.TryGetValue(shopName, out var shop);
             if (shop == null)
             {
                 return false;
@@ -58,7 +60,8 @@ namespace ShopTileFramework.API
         public bool OpenAnimalShop(string shopName)
         {
             //opens up the shop of ShopName in-game
-            ShopManager.AnimalShops.TryGetValue(shopName, out var shop);
+            Dictionary<string, AnimalShop> animalShops = ModEntry.helper.Content.Load<Dictionary<string, AnimalShop>>("Mods/ShopTileFramework/AnimalShops", ContentSource.GameContent);
+            animalShops.TryGetValue(shopName, out var shop);
             if (shop == null)
             {
                 return false;
@@ -76,7 +79,8 @@ namespace ShopTileFramework.API
         public bool ResetShopStock(string shopName)
         {
             //resets the stock of the given ShopName
-            ShopManager.ItemShops.TryGetValue(shopName, out var shop);
+            Dictionary<string, ItemShop> itemShops = ModEntry.helper.Content.Load<Dictionary<string, ItemShop>>("Mods/ShopTileFramework/ItemShops", ContentSource.GameContent);
+            itemShops.TryGetValue(shopName, out var shop);
             if (shop == null)
             {
                 return false;
@@ -94,7 +98,8 @@ namespace ShopTileFramework.API
         public Dictionary<ISalable, int[]> GetItemPriceAndStock(string shopName)
         {
             //gets the ItemStockAndPrice of the given ShopName
-            ShopManager.ItemShops.TryGetValue(shopName, out var shop);
+            Dictionary<string, ItemShop> itemShops = ModEntry.helper.Content.Load<Dictionary<string, ItemShop>>("Mods/ShopTileFramework/ItemShops", ContentSource.GameContent);
+            itemShops.TryGetValue(shopName, out var shop);
             if (shop == null)
             {
                 return null;

--- a/ShopTileFramework/src/ModEntry.cs
+++ b/ShopTileFramework/src/ModEntry.cs
@@ -28,6 +28,7 @@ namespace ShopTileFramework
         private bool _changedMarnieStock;
         internal static GameLocation SourceLocation;
         private static Vector2 _playerPos = Vector2.Zero;
+        internal static ShopManager ShopManager;
 
         public static bool VerboseLogging;
 
@@ -60,7 +61,12 @@ namespace ShopTileFramework
             new ConsoleCommands().Register(helper);
 
             //get all the info from content packs
+            ShopManager = new ShopManager();
             ShopManager.LoadContentPacks();
+
+            //load data into game content
+            helper.Content.AssetLoaders.Add(ShopManager);
+            helper.Content.AssetEditors.Add(ShopManager);
 
             HarmonyInstance harmony = HarmonyInstance.Create(this.ModManifest.UniqueID);
             VanillaShopStockPatches.Apply(harmony);
@@ -275,7 +281,7 @@ namespace ShopTileFramework
                 else //no vanilla shop found
                 {
                     //Extract the tile property value
-                    Dictionary<string, ItemShop> itemShops = helper.Content.Load<Dictionary<string, ItemShop>>("Mods/ShopTileFramework/ItemShops", ContentSource.GameContent);
+                    Dictionary<string, ItemShop> itemShops = Game1.content.Load<Dictionary<string, ItemShop>>("Mods/ShopTileFramework/ItemShops");
                     string shopName = shopProperty.ToString();
 
                     if (itemShops.ContainsKey(shopName))
@@ -297,7 +303,8 @@ namespace ShopTileFramework
                 if (shopProperty != null) //no animal shop found
                 {
                     string shopName = shopProperty.ToString();
-                    Dictionary<string, AnimalShop> animalShops = helper.Content.Load<Dictionary<string, AnimalShop>>("Mods/ShopTileFramework/AnimalShops", ContentSource.GameContent);
+
+                    Dictionary<string, AnimalShop> animalShops = Game1.content.Load<Dictionary<string, AnimalShop>>("Mods/ShopTileFramework/AnimalShops");
                     if (animalShops.ContainsKey(shopName))
                     {
                         //stop the click action from going through after the menu has been opened

--- a/ShopTileFramework/src/ModEntry.cs
+++ b/ShopTileFramework/src/ModEntry.cs
@@ -1,4 +1,6 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
 using Harmony;
 using Microsoft.Xna.Framework;
 using ShopTileFramework.API;
@@ -6,9 +8,10 @@ using ShopTileFramework.Patches;
 using ShopTileFramework.Shop;
 using ShopTileFramework.Utility;
 using StardewModdingAPI;
+using StardewModdingAPI.Events;
+using StardewModdingAPI.Utilities;
 using StardewValley;
 using StardewValley.Menus;
-using System.Linq;
 using xTile.ObjectModel;
 
 namespace ShopTileFramework
@@ -76,7 +79,7 @@ namespace ShopTileFramework
         /// </summary>
         /// <param name="sender"></param>
         /// <param name="e"></param>
-        private void GameLoop_UpdateTicking(object sender, StardewModdingAPI.Events.UpdateTickingEventArgs e)
+        private void GameLoop_UpdateTicking(object sender, UpdateTickingEventArgs e)
         {
             //Fixes the game warping the player to places we don't want them to warp
             //if buildings/animal purchase menus are brought up from a custom tile
@@ -95,7 +98,7 @@ namespace ShopTileFramework
         /// </summary>
         /// <param name="sender"></param>
         /// <param name="e"></param>
-        private void Display_MenuChanged(object sender, StardewModdingAPI.Events.MenuChangedEventArgs e)
+        private void Display_MenuChanged(object sender, MenuChangedEventArgs e)
         {
             //this block fixes marnie's portrait popping up after purchasing an animal
             if (e.OldMenu is PurchaseAnimalsMenu && e.NewMenu is DialogueBox && SourceLocation != null)
@@ -151,7 +154,7 @@ namespace ShopTileFramework
         /// </summary>
         /// <param name="sender"></param>
         /// <param name="e"></param>
-        private void GameLoop_SaveLoaded(object sender, StardewModdingAPI.Events.SaveLoadedEventArgs e)
+        private void GameLoop_SaveLoaded(object sender, SaveLoadedEventArgs e)
         {
             Translations.UpdateSelectedLanguage();
             ShopManager.UpdateTranslations();
@@ -167,7 +170,7 @@ namespace ShopTileFramework
         /// </summary>
         /// <param name="sender"></param>
         /// <param name="e"></param>
-        private void GameLoop_GameLaunched(object sender, StardewModdingAPI.Events.GameLaunchedEventArgs e)
+        private void GameLoop_GameLaunched(object sender, GameLaunchedEventArgs e)
         {
             ShopManager.InitializeShops();
 
@@ -180,7 +183,7 @@ namespace ShopTileFramework
             APIs.RegisterFAVR();
         }
 
-        private void JsonAssets_AddedItemsToShop(object sender, System.EventArgs e)
+        private void JsonAssets_AddedItemsToShop(object sender, EventArgs e)
         {
             //make sure we only remove all objects if we camew from a vanilla store
             //this stops us from removing all packs from custom TMXL or STF stores
@@ -200,7 +203,7 @@ namespace ShopTileFramework
         /// </summary>
         /// <param name="sender"></param>
         /// <param name="e"></param>
-        private void GameLoop_DayStarted(object sender, StardewModdingAPI.Events.DayStartedEventArgs e)
+        private void GameLoop_DayStarted(object sender, DayStartedEventArgs e)
         {
             ShopManager.UpdateStock();
         }
@@ -211,7 +214,7 @@ namespace ShopTileFramework
         /// </summary>
         /// <param name="sender"></param>
         /// <param name="e"></param>
-        private void Input_ButtonPressed(object sender, StardewModdingAPI.Events.ButtonPressedEventArgs e)
+        private void Input_ButtonPressed(object sender, ButtonPressedEventArgs e)
         {
             //context and button check
             if (!Context.CanPlayerMove)
@@ -254,7 +257,7 @@ namespace ShopTileFramework
         /// </summary>
         /// <param name="tileProperty"></param>
         /// <param name="e"></param>
-        private void CheckForShopToOpen(IPropertyCollection tileProperty, StardewModdingAPI.Events.ButtonPressedEventArgs e)
+        private void CheckForShopToOpen(IPropertyCollection tileProperty, ButtonPressedEventArgs e)
         {
             //check if there is a Shop property on clicked tile
             tileProperty.TryGetValue("Shop", out PropertyValue shopProperty);
@@ -280,7 +283,7 @@ namespace ShopTileFramework
                 else //no vanilla shop found
                 {
                     //Extract the tile property value
-                    Dictionary<string, ItemShop> itemShops = Game1.content.Load<Dictionary<string, ItemShop>>("Mods/ShopTileFramework/ItemShops");
+                    Dictionary<string, ItemShop> itemShops = Game1.content.Load<Dictionary<string, ItemShop>>(PathUtilities.NormalizePath("Mods/ShopTileFramework/ItemShops"));
                     string shopName = shopProperty.ToString();
 
                     if (itemShops.ContainsKey(shopName))
@@ -303,7 +306,7 @@ namespace ShopTileFramework
                 {
                     string shopName = shopProperty.ToString();
 
-                    Dictionary<string, AnimalShop> animalShops = Game1.content.Load<Dictionary<string, AnimalShop>>("Mods/ShopTileFramework/AnimalShops");
+                    Dictionary<string, AnimalShop> animalShops = Game1.content.Load<Dictionary<string, AnimalShop>>(PathUtilities.NormalizePath("Mods/ShopTileFramework/AnimalShops"));
                     if (animalShops.ContainsKey(shopName))
                     {
                         //stop the click action from going through after the menu has been opened

--- a/ShopTileFramework/src/ModEntry.cs
+++ b/ShopTileFramework/src/ModEntry.cs
@@ -66,7 +66,6 @@ namespace ShopTileFramework
 
             //load data into game content
             helper.Content.AssetLoaders.Add(ShopManager);
-            helper.Content.AssetEditors.Add(ShopManager);
 
             HarmonyInstance harmony = HarmonyInstance.Create(this.ModManifest.UniqueID);
             VanillaShopStockPatches.Apply(harmony);

--- a/ShopTileFramework/src/ModEntry.cs
+++ b/ShopTileFramework/src/ModEntry.cs
@@ -1,4 +1,5 @@
-﻿using Harmony;
+﻿using System.Collections.Generic;
+using Harmony;
 using Microsoft.Xna.Framework;
 using ShopTileFramework.API;
 using ShopTileFramework.Patches;
@@ -274,13 +275,14 @@ namespace ShopTileFramework
                 else //no vanilla shop found
                 {
                     //Extract the tile property value
+                    Dictionary<string, ItemShop> itemShops = helper.Content.Load<Dictionary<string, ItemShop>>("Mods/ShopTileFramework/ItemShops", ContentSource.GameContent);
                     string shopName = shopProperty.ToString();
 
-                    if (ShopManager.ItemShops.ContainsKey(shopName))
+                    if (itemShops.ContainsKey(shopName))
                     {
                         //stop the click action from going through after the menu has been opened
                         helper.Input.Suppress(e.Button);
-                        ShopManager.ItemShops[shopName].DisplayShop();
+                        itemShops[shopName].DisplayShop();
                     }
                     else
                     {
@@ -295,11 +297,12 @@ namespace ShopTileFramework
                 if (shopProperty != null) //no animal shop found
                 {
                     string shopName = shopProperty.ToString();
-                    if (ShopManager.AnimalShops.ContainsKey(shopName))
+                    Dictionary<string, AnimalShop> animalShops = helper.Content.Load<Dictionary<string, AnimalShop>>("Mods/ShopTileFramework/AnimalShops", ContentSource.GameContent);
+                    if (animalShops.ContainsKey(shopName))
                     {
                         //stop the click action from going through after the menu has been opened
                         helper.Input.Suppress(e.Button);
-                        ShopManager.AnimalShops[shopName].DisplayShop();
+                        animalShops[shopName].DisplayShop();
                     }
                     else
                     {

--- a/ShopTileFramework/src/Patches/VanillaShopStockPatches.cs
+++ b/ShopTileFramework/src/Patches/VanillaShopStockPatches.cs
@@ -6,6 +6,7 @@ using StardewValley.Locations;
 using System.Collections.Generic;
 using System.Linq;
 using StardewModdingAPI;
+using StardewModdingAPI.Utilities;
 
 namespace ShopTileFramework.Patches
 {
@@ -105,7 +106,7 @@ namespace ShopTileFramework.Patches
         {
             ModEntry.JustOpenedVanilla = true;
 
-            Dictionary<string, VanillaShop> vanillaShops = Game1.content.Load<Dictionary<string, VanillaShop>>("Mods/ShopTileFramework/VanillaShops");
+            Dictionary<string, VanillaShop> vanillaShops = Game1.content.Load<Dictionary<string, VanillaShop>>(PathUtilities.NormalizePath("Mods/ShopTileFramework/VanillaShops"));
             if (!vanillaShops.ContainsKey(shopName)) return;
 
             var customStock = vanillaShops[shopName].ItemPriceAndStock;

--- a/ShopTileFramework/src/Patches/VanillaShopStockPatches.cs
+++ b/ShopTileFramework/src/Patches/VanillaShopStockPatches.cs
@@ -5,6 +5,7 @@ using StardewValley;
 using StardewValley.Locations;
 using System.Collections.Generic;
 using System.Linq;
+using StardewModdingAPI;
 
 namespace ShopTileFramework.Patches
 {
@@ -104,11 +105,12 @@ namespace ShopTileFramework.Patches
         {
             ModEntry.JustOpenedVanilla = true;
 
-            if (!ShopManager.VanillaShops.ContainsKey(shopName)) return;
+            Dictionary<string, VanillaShop> vanillaShops = ModEntry.helper.Content.Load<Dictionary<string, VanillaShop>>("Mods/ShopTileFramework/VanillaShops", ContentSource.GameContent);
+            if (!vanillaShops.ContainsKey(shopName)) return;
 
-            var customStock = ShopManager.VanillaShops[shopName].ItemPriceAndStock;
+            var customStock = vanillaShops[shopName].ItemPriceAndStock;
             ItemsUtil.RemoveSoldOutItems(customStock);
-            if (ShopManager.VanillaShops[shopName].ReplaceInsteadOfAdd)
+            if (vanillaShops[shopName].ReplaceInsteadOfAdd)
             {
                 __result = customStock;
             }
@@ -120,7 +122,7 @@ namespace ShopTileFramework.Patches
                         return;
                 }
 
-                if (ShopManager.VanillaShops[shopName].AddStockAboveVanilla)
+                if (vanillaShops[shopName].AddStockAboveVanilla)
                 {
                     __result = customStock.Concat(__result).ToDictionary(x => x.Key, x => x.Value);
                 }

--- a/ShopTileFramework/src/Patches/VanillaShopStockPatches.cs
+++ b/ShopTileFramework/src/Patches/VanillaShopStockPatches.cs
@@ -105,7 +105,7 @@ namespace ShopTileFramework.Patches
         {
             ModEntry.JustOpenedVanilla = true;
 
-            Dictionary<string, VanillaShop> vanillaShops = ModEntry.helper.Content.Load<Dictionary<string, VanillaShop>>("Mods/ShopTileFramework/VanillaShops", ContentSource.GameContent);
+            Dictionary<string, VanillaShop> vanillaShops = Game1.content.Load<Dictionary<string, VanillaShop>>("Mods/ShopTileFramework/VanillaShops");
             if (!vanillaShops.ContainsKey(shopName)) return;
 
             var customStock = vanillaShops[shopName].ItemPriceAndStock;

--- a/ShopTileFramework/src/Shop/ShopManager.cs
+++ b/ShopTileFramework/src/Shop/ShopManager.cs
@@ -194,7 +194,7 @@ namespace ShopTileFramework.Shop
         /// </summary>
         internal void UpdateStock()
         {
-            Dictionary<string, ItemShop> itemShops = Game1.content.Load<Dictionary<string, ItemShop>>("Mods/ShopTileFramework/ItemShops");
+            Dictionary<string, ItemShop> itemShops = Game1.content.Load<Dictionary<string, ItemShop>>(PathUtilities.NormalizePath("Mods/ShopTileFramework/ItemShops"));
             if (itemShops.Count > 0)
                 ModEntry.monitor.Log($"Refreshing stock for all custom shops...", LogLevel.Debug);
 
@@ -204,7 +204,7 @@ namespace ShopTileFramework.Shop
                 store.UpdatePortrait();
             }
 
-            Dictionary<string, VanillaShop> vanillaShops = Game1.content.Load<Dictionary<string, VanillaShop>>("Mods/ShopTileFramework/VanillaShops");
+            Dictionary<string, VanillaShop> vanillaShops = Game1.content.Load<Dictionary<string, VanillaShop>>(PathUtilities.NormalizePath("Mods/ShopTileFramework/VanillaShops"));
             if (vanillaShops.Count > 0)
                 ModEntry.monitor.Log($"Refreshing stock for all Vanilla shops...", LogLevel.Debug);
 
@@ -219,9 +219,11 @@ namespace ShopTileFramework.Shop
         /// </summary>
         public bool CanLoad<T>(IAssetInfo asset)
         {
-            return asset.AssetNameEquals("Mods/ShopTileFramework/ItemShops") 
-                || asset.AssetNameEquals("Mods/ShopTileFramework/AnimalShops") 
-                || asset.AssetNameEquals("Mods/ShopTileFramework/VanillaShops");
+            var assetName = PathUtilities.NormalizePath(asset.AssetName);
+            var modPath = PathUtilities.NormalizePath("Mods/ShopTileFramework/");
+            return assetName.Equals($"{modPath}ItemShops")
+                || assetName.Equals($"{modPath}AnimalShops")
+                || assetName.Equals($"{modPath}VanillaShops");
         }
 
         /// <summary>

--- a/ShopTileFramework/src/Shop/ShopManager.cs
+++ b/ShopTileFramework/src/Shop/ShopManager.cs
@@ -236,7 +236,7 @@ namespace ShopTileFramework.Shop
                 case "VanillaShops":
                     return (T) (object) new Dictionary<string, VanillaShop>();
             }
-            throw new NotImplementedException();
+            throw new InvalidOperationException();
         }
 
         /// <summary>
@@ -244,9 +244,9 @@ namespace ShopTileFramework.Shop
         /// </summary>
         public bool CanEdit<T>(IAssetInfo asset)
         {
-            return asset.AssetNameEquals("Mods/ShopTileFramework/ItemShops.xnb") 
-                || asset.AssetNameEquals("Mods/ShopTileFramework/AnimalShops.xnb") 
-                || asset.AssetNameEquals("Mods/ShopTileFramework/VanillaShops.xnb");
+            return asset.AssetNameEquals("Mods/ShopTileFramework/ItemShops") 
+                || asset.AssetNameEquals("Mods/ShopTileFramework/AnimalShops") 
+                || asset.AssetNameEquals("Mods/ShopTileFramework/VanillaShops");
         }
 
         /// <summary>

--- a/ShopTileFramework/src/Shop/ShopManager.cs
+++ b/ShopTileFramework/src/Shop/ShopManager.cs
@@ -5,6 +5,7 @@ using StardewModdingAPI;
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using StardewModdingAPI.Utilities;
 
 namespace ShopTileFramework.Shop
 {
@@ -12,11 +13,11 @@ namespace ShopTileFramework.Shop
     /// This class holds and manages all the shops, loading content packs to create shops
     /// And containing methods to update everything that needs to
     /// </summary>
-    class ShopManager
+    class ShopManager : IAssetLoader, IAssetEditor
     {
-        public static Dictionary<string, ItemShop> ItemShops = new Dictionary<string, ItemShop>();
-        public static Dictionary<string, AnimalShop> AnimalShops = new Dictionary<string, AnimalShop>();
-        public static Dictionary<string, VanillaShop> VanillaShops = new Dictionary<string, VanillaShop>();
+        private static Dictionary<string, ItemShop> ItemShops = new Dictionary<string, ItemShop>();
+        private static Dictionary<string, AnimalShop> AnimalShops = new Dictionary<string, AnimalShop>();
+        private static Dictionary<string, VanillaShop> VanillaShops = new Dictionary<string, VanillaShop>();
         public static readonly string[] VanillaShopNames = {
             "PierreShop",
             "JojaShop",
@@ -210,5 +211,77 @@ namespace ShopTileFramework.Shop
             }
         }
 
+        /// <summary>
+        /// Provide original versions of Game content loaded to Mods/ShopTileFramework/%
+        /// </summary>
+        public bool CanLoad<T>(IAssetInfo asset)
+        {
+            return asset.AssetNameEquals("Mods/ShopTileFramework/ItemShops") 
+                || asset.AssetNameEquals("Mods/ShopTileFramework/AnimalShops") 
+                || asset.AssetNameEquals("Mods/ShopTileFramework/VanillaShops");
+        }
+
+        /// <summary>
+        /// Initialize Shop Dictionary for Content Mod target
+        /// </summary>
+        public T Load<T>(IAssetInfo asset)
+        {
+            string shopType = PathUtilities.GetSegments(asset.AssetName).ElementAtOrDefault(2);
+            switch (shopType)
+            {
+                case "ItemShops":
+                    return (T) (object) new Dictionary<string, ItemShop>();
+                case "AnimalShops":
+                    return (T) (object) new Dictionary<string, AnimalShop>();
+                case "VanillaShops":
+                    return (T) (object) new Dictionary<string, VanillaShop>();
+            }
+            throw new NotImplementedException();
+        }
+
+        /// <summary>
+        /// Edit to add ItemShops/AnimalShops/VanillaShops
+        /// </summary>
+        public bool CanEdit<T>(IAssetInfo asset)
+        {
+            return asset.AssetNameEquals("Mods/ShopTileFramework/ItemShops") 
+                   || asset.AssetNameEquals("Mods/ShopTileFramework/AnimalShops") 
+                   || asset.AssetNameEquals("Mods/ShopTileFramework/VanillaShops");
+        }
+
+        /// <summary>
+        /// Load Shops from Content Pack data
+        /// </summary>
+        public void Edit<T>(IAssetData asset)
+        {
+            string shopType = PathUtilities.GetSegments(asset.AssetName).ElementAtOrDefault(2);
+            switch (shopType)
+            {
+                case "ItemShops":
+                    IDictionary<string, ItemShop> itemShops = asset.AsDictionary<string, ItemShop>().Data;
+                    foreach (var itemShop in ItemShops)
+                    {
+                        if (!itemShops.ContainsKey(itemShop.Key))
+                            itemShops.Add(itemShop.Key, itemShop.Value);
+                    }
+                    break;
+                case "AnimalShops":
+                    IDictionary<string, AnimalShop> animalShops = asset.AsDictionary<string, AnimalShop>().Data;
+                    foreach (var animalShop in AnimalShops)
+                    {
+                        if (!animalShops.ContainsKey(animalShop.Key))
+                            animalShops.Add(animalShop.Key, animalShop.Value);
+                    }
+                    break;
+                case "VanillaShops":
+                    IDictionary<string, VanillaShop> vanillaShops = asset.AsDictionary<string, VanillaShop>().Data;
+                    foreach (var vanillaShop in VanillaShops)
+                    {
+                        if (vanillaShops.ContainsKey(vanillaShop.Key))
+                            vanillaShops.Add(vanillaShop.Key, vanillaShop.Value);
+                    }
+                    break;
+            }
+        }
     }
 }

--- a/ShopTileFramework/src/Shop/ShopManager.cs
+++ b/ShopTileFramework/src/Shop/ShopManager.cs
@@ -6,6 +6,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using StardewModdingAPI.Utilities;
+using StardewValley;
 
 namespace ShopTileFramework.Shop
 {
@@ -13,7 +14,7 @@ namespace ShopTileFramework.Shop
     /// This class holds and manages all the shops, loading content packs to create shops
     /// And containing methods to update everything that needs to
     /// </summary>
-    class ShopManager : IAssetLoader, IAssetEditor
+    class ShopManager : IAssetLoader
     {
         private readonly Dictionary<string, ItemShop> ItemShops = new Dictionary<string, ItemShop>();
         private readonly Dictionary<string, AnimalShop> AnimalShops = new Dictionary<string, AnimalShop>();
@@ -193,19 +194,21 @@ namespace ShopTileFramework.Shop
         /// </summary>
         internal void UpdateStock()
         {
-            if (ItemShops.Count > 0)
+            Dictionary<string, ItemShop> itemShops = Game1.content.Load<Dictionary<string, ItemShop>>("Mods/ShopTileFramework/ItemShops");
+            if (itemShops.Count > 0)
                 ModEntry.monitor.Log($"Refreshing stock for all custom shops...", LogLevel.Debug);
 
-            foreach (ItemShop store in ItemShops.Values)
+            foreach (ItemShop store in itemShops.Values)
             {
                 store.UpdateItemPriceAndStock();
                 store.UpdatePortrait();
             }
 
-            if (VanillaShops.Count > 0)
+            Dictionary<string, VanillaShop> vanillaShops = Game1.content.Load<Dictionary<string, VanillaShop>>("Mods/ShopTileFramework/VanillaShops");
+            if (vanillaShops.Count > 0)
                 ModEntry.monitor.Log($"Refreshing stock for all Vanilla shops...", LogLevel.Debug);
 
-            foreach (VanillaShop shop in VanillaShops.Values)
+            foreach (VanillaShop shop in vanillaShops.Values)
             {
                 shop.UpdateItemPriceAndStock();
             }
@@ -237,39 +240,6 @@ namespace ShopTileFramework.Shop
                     return (T) (object) VanillaShops;
             }
             throw new InvalidOperationException();
-        }
-
-        /// <summary>
-        /// Refresh prices one tick after edit
-        /// </summary>
-        public bool CanEdit<T>(IAssetInfo asset)
-        {
-            if (asset.AssetNameEquals("Mods/ShopTileFramework/ItemShops")
-                || asset.AssetNameEquals("Mods/ShopTileFramework/AnimalShops")
-                || asset.AssetNameEquals("Mods/ShopTileFramework/VanillaShops"))
-            {
-                ModEntry.helper.Events.GameLoop.UpdateTicked += GameLoop_UpdateTicked;
-            }
-
-            return false;
-        }
-
-        /// <summary>
-        /// Required, but this should never get called
-        /// </summary>
-        public void Edit<T>(IAssetData asset)
-        {
-            throw new InvalidOperationException();
-        }
-
-        /// <summary>
-        /// Refresh all stock prices
-        /// </summary>
-        private void GameLoop_UpdateTicked(object sender, StardewModdingAPI.Events.UpdateTickedEventArgs e)
-        {
-            
-            ModEntry.helper.Events.GameLoop.UpdateTicked -= GameLoop_UpdateTicked;
-            UpdateStock();
         }
     }
 }

--- a/ShopTileFramework/src/Shop/ShopManager.cs
+++ b/ShopTileFramework/src/Shop/ShopManager.cs
@@ -15,10 +15,10 @@ namespace ShopTileFramework.Shop
     /// </summary>
     class ShopManager : IAssetLoader, IAssetEditor
     {
-        private static Dictionary<string, ItemShop> ItemShops = new Dictionary<string, ItemShop>();
-        private static Dictionary<string, AnimalShop> AnimalShops = new Dictionary<string, AnimalShop>();
-        private static Dictionary<string, VanillaShop> VanillaShops = new Dictionary<string, VanillaShop>();
-        public static readonly string[] VanillaShopNames = {
+        private readonly Dictionary<string, ItemShop> ItemShops = new Dictionary<string, ItemShop>();
+        private readonly Dictionary<string, AnimalShop> AnimalShops = new Dictionary<string, AnimalShop>();
+        private readonly Dictionary<string, VanillaShop> VanillaShops = new Dictionary<string, VanillaShop>();
+        private readonly string[] VanillaShopNames = {
             "PierreShop",
             "JojaShop",
             "RobinShop",
@@ -41,7 +41,7 @@ namespace ShopTileFramework.Shop
         /// <summary>
         /// Takes content packs and loads them as ItemShop and AnimalShop objects
         /// </summary>
-        public static void LoadContentPacks()
+        public void LoadContentPacks()
         {
             ModEntry.monitor.Log("Adding Content Packs...", LogLevel.Info);
             foreach (IContentPack contentPack in ModEntry.helper.ContentPacks.GetOwned())
@@ -77,7 +77,7 @@ namespace ShopTileFramework.Shop
         /// </summary>
         /// <param name="data"></param>
         /// <param name="contentPack"></param>
-        public static void RegisterShops(ContentPack data, IContentPack contentPack)
+        public void RegisterShops(ContentPack data, IContentPack contentPack)
         {
             ItemsUtil.RegisterPacksToRemove(data.RemovePacksFromVanilla, data.RemovePackRecipesFromVanilla, data.RemoveItemsFromVanilla);
 
@@ -147,7 +147,7 @@ namespace ShopTileFramework.Shop
         /// <summary>
         /// Update all trans;ations for each shop when a save file is loaded
         /// </summary>
-        public static void UpdateTranslations()
+        public void UpdateTranslations()
         {
             foreach (ItemShop itemShop in ItemShops.Values)
             {
@@ -163,7 +163,7 @@ namespace ShopTileFramework.Shop
         /// <summary>
         /// Initializes all shops once the game is loaded
         /// </summary>
-        public static void InitializeShops()
+        public void InitializeShops()
         {
             foreach (ItemShop itemShop in ItemShops.Values)
             {
@@ -174,7 +174,7 @@ namespace ShopTileFramework.Shop
         /// <summary>
         /// Initializes the stocks of each shop after the save file has loaded so that item IDs are available to generate items
         /// </summary>
-        public static void InitializeItemStocks()
+        public void InitializeItemStocks()
         {
             foreach (ItemShop itemShop in ItemShops.Values)
             {
@@ -191,7 +191,7 @@ namespace ShopTileFramework.Shop
         /// Updates the stock for all itemshops at the start of each day
         /// and updates their portraits too to match the current season
         /// </summary>
-        internal static void UpdateStock()
+        internal void UpdateStock()
         {
             if (ItemShops.Count > 0)
                 ModEntry.monitor.Log($"Refreshing stock for all custom shops...", LogLevel.Debug);
@@ -244,9 +244,9 @@ namespace ShopTileFramework.Shop
         /// </summary>
         public bool CanEdit<T>(IAssetInfo asset)
         {
-            return asset.AssetNameEquals("Mods/ShopTileFramework/ItemShops") 
-                   || asset.AssetNameEquals("Mods/ShopTileFramework/AnimalShops") 
-                   || asset.AssetNameEquals("Mods/ShopTileFramework/VanillaShops");
+            return asset.AssetNameEquals("Mods/ShopTileFramework/ItemShops.xnb") 
+                || asset.AssetNameEquals("Mods/ShopTileFramework/AnimalShops.xnb") 
+                || asset.AssetNameEquals("Mods/ShopTileFramework/VanillaShops.xnb");
         }
 
         /// <summary>

--- a/ShopTileFramework/src/Shop/ShopManager.cs
+++ b/ShopTileFramework/src/Shop/ShopManager.cs
@@ -230,58 +230,46 @@ namespace ShopTileFramework.Shop
             switch (shopType)
             {
                 case "ItemShops":
-                    return (T) (object) new Dictionary<string, ItemShop>();
+                    return (T) (object) ItemShops;
                 case "AnimalShops":
-                    return (T) (object) new Dictionary<string, AnimalShop>();
+                    return (T) (object) AnimalShops;
                 case "VanillaShops":
-                    return (T) (object) new Dictionary<string, VanillaShop>();
+                    return (T) (object) VanillaShops;
             }
             throw new InvalidOperationException();
         }
 
         /// <summary>
-        /// Edit to add ItemShops/AnimalShops/VanillaShops
+        /// Refresh prices one tick after edit
         /// </summary>
         public bool CanEdit<T>(IAssetInfo asset)
         {
-            return asset.AssetNameEquals("Mods/ShopTileFramework/ItemShops") 
-                || asset.AssetNameEquals("Mods/ShopTileFramework/AnimalShops") 
-                || asset.AssetNameEquals("Mods/ShopTileFramework/VanillaShops");
+            if (asset.AssetNameEquals("Mods/ShopTileFramework/ItemShops")
+                || asset.AssetNameEquals("Mods/ShopTileFramework/AnimalShops")
+                || asset.AssetNameEquals("Mods/ShopTileFramework/VanillaShops"))
+            {
+                ModEntry.helper.Events.GameLoop.UpdateTicked += GameLoop_UpdateTicked;
+            }
+
+            return false;
         }
 
         /// <summary>
-        /// Load Shops from Content Pack data
+        /// Required, but this should never get called
         /// </summary>
         public void Edit<T>(IAssetData asset)
         {
-            string shopType = PathUtilities.GetSegments(asset.AssetName).ElementAtOrDefault(2);
-            switch (shopType)
-            {
-                case "ItemShops":
-                    IDictionary<string, ItemShop> itemShops = asset.AsDictionary<string, ItemShop>().Data;
-                    foreach (var itemShop in ItemShops)
-                    {
-                        if (!itemShops.ContainsKey(itemShop.Key))
-                            itemShops.Add(itemShop.Key, itemShop.Value);
-                    }
-                    break;
-                case "AnimalShops":
-                    IDictionary<string, AnimalShop> animalShops = asset.AsDictionary<string, AnimalShop>().Data;
-                    foreach (var animalShop in AnimalShops)
-                    {
-                        if (!animalShops.ContainsKey(animalShop.Key))
-                            animalShops.Add(animalShop.Key, animalShop.Value);
-                    }
-                    break;
-                case "VanillaShops":
-                    IDictionary<string, VanillaShop> vanillaShops = asset.AsDictionary<string, VanillaShop>().Data;
-                    foreach (var vanillaShop in VanillaShops)
-                    {
-                        if (vanillaShops.ContainsKey(vanillaShop.Key))
-                            vanillaShops.Add(vanillaShop.Key, vanillaShop.Value);
-                    }
-                    break;
-            }
+            throw new InvalidOperationException();
+        }
+
+        /// <summary>
+        /// Refresh all stock prices
+        /// </summary>
+        private void GameLoop_UpdateTicked(object sender, StardewModdingAPI.Events.UpdateTickedEventArgs e)
+        {
+            
+            ModEntry.helper.Events.GameLoop.UpdateTicked -= GameLoop_UpdateTicked;
+            UpdateStock();
         }
     }
 }

--- a/ShopTileFramework/src/Utility/ConsoleCommands.cs
+++ b/ShopTileFramework/src/Utility/ConsoleCommands.cs
@@ -1,4 +1,5 @@
-﻿using ShopTileFramework.API;
+﻿using System.Collections.Generic;
+using ShopTileFramework.API;
 using ShopTileFramework.Shop;
 using StardewModdingAPI;
 
@@ -62,7 +63,8 @@ namespace ShopTileFramework.Utility
                 return;
             }
 
-            ShopManager.ItemShops.TryGetValue(args[0], out ItemShop value);
+            Dictionary<string, ItemShop> itemShops = ModEntry.helper.Content.Load<Dictionary<string, ItemShop>>("Mods/ShopTileFramework/ItemShops", ContentSource.GameContent);
+            itemShops.TryGetValue(args[0], out ItemShop value);
             if (value == null)
             {
                 ModEntry.monitor.Log($"No shop with a name of {args[0]} was found.", LogLevel.Debug);
@@ -92,7 +94,8 @@ namespace ShopTileFramework.Utility
                 return;
             }
 
-            ShopManager.AnimalShops.TryGetValue(args[0], out AnimalShop value);
+            Dictionary<string, AnimalShop> animalShops = ModEntry.helper.Content.Load<Dictionary<string, AnimalShop>>("Mods/ShopTileFramework/AnimalShops", ContentSource.GameContent);
+            animalShops.TryGetValue(args[0], out AnimalShop value);
             if (value == null)
             {
                 ModEntry.monitor.Log($"No shop with a name of {args[0]} was found.", LogLevel.Debug);
@@ -122,7 +125,8 @@ namespace ShopTileFramework.Utility
                 return;
             }
 
-            ShopManager.ItemShops.TryGetValue(args[0], out ItemShop shop);
+            Dictionary<string, ItemShop> itemShops = ModEntry.helper.Content.Load<Dictionary<string, ItemShop>>("Mods/ShopTileFramework/ItemShops", ContentSource.GameContent);
+            itemShops.TryGetValue(args[0], out ItemShop shop);
             if (shop == null)
             {
                 ModEntry.monitor.Log($"No shop with a name of {args[0]} was found.", LogLevel.Debug);
@@ -143,19 +147,21 @@ namespace ShopTileFramework.Utility
         /// </summary>
         private void ListAllShops(string command, string[] args)
         {
-            if (ShopManager.ItemShops.Count == 0)
+            Dictionary<string, ItemShop> itemShops = ModEntry.helper.Content.Load<Dictionary<string, ItemShop>>("Mods/ShopTileFramework/ItemShops", ContentSource.GameContent);
+            Dictionary<string, AnimalShop> animalShops = ModEntry.helper.Content.Load<Dictionary<string, AnimalShop>>("Mods/ShopTileFramework/AnimalShops", ContentSource.GameContent);
+            if (itemShops.Count == 0)
             {
                 ModEntry.monitor.Log($"No shops were found", LogLevel.Debug);
             }
             else
             {
                 string temp = "";
-                foreach (string k in ShopManager.ItemShops.Keys)
+                foreach (string k in itemShops.Keys)
                 {
                     temp += "\nShop: " + k;
                 }
 
-                foreach (string k in ShopManager.AnimalShops.Keys)
+                foreach (string k in animalShops.Keys)
                 {
                     temp += "\nAnimalShop: " + k;
                 }

--- a/ShopTileFramework/src/Utility/ConsoleCommands.cs
+++ b/ShopTileFramework/src/Utility/ConsoleCommands.cs
@@ -2,6 +2,7 @@
 using ShopTileFramework.API;
 using ShopTileFramework.Shop;
 using StardewModdingAPI;
+using StardewModdingAPI.Utilities;
 using StardewValley;
 
 namespace ShopTileFramework.Utility
@@ -64,7 +65,7 @@ namespace ShopTileFramework.Utility
                 return;
             }
 
-            Dictionary<string, ItemShop> itemShops = Game1.content.Load<Dictionary<string, ItemShop>>("Mods/ShopTileFramework/ItemShops");
+            Dictionary<string, ItemShop> itemShops = Game1.content.Load<Dictionary<string, ItemShop>>(PathUtilities.NormalizePath("Mods/ShopTileFramework/ItemShops"));
             itemShops.TryGetValue(args[0], out ItemShop value);
             if (value == null)
             {
@@ -95,7 +96,7 @@ namespace ShopTileFramework.Utility
                 return;
             }
 
-            Dictionary<string, AnimalShop> animalShops = Game1.content.Load<Dictionary<string, AnimalShop>>("Mods/ShopTileFramework/AnimalShops");
+            Dictionary<string, AnimalShop> animalShops = Game1.content.Load<Dictionary<string, AnimalShop>>(PathUtilities.NormalizePath("Mods/ShopTileFramework/AnimalShops"));
             animalShops.TryGetValue(args[0], out AnimalShop value);
             if (value == null)
             {
@@ -126,7 +127,7 @@ namespace ShopTileFramework.Utility
                 return;
             }
 
-            Dictionary<string, ItemShop> itemShops = Game1.content.Load<Dictionary<string, ItemShop>>("Mods/ShopTileFramework/ItemShops");
+            Dictionary<string, ItemShop> itemShops = Game1.content.Load<Dictionary<string, ItemShop>>(PathUtilities.NormalizePath("Mods/ShopTileFramework/ItemShops"));
             itemShops.TryGetValue(args[0], out ItemShop shop);
             if (shop == null)
             {
@@ -148,8 +149,8 @@ namespace ShopTileFramework.Utility
         /// </summary>
         private void ListAllShops(string command, string[] args)
         {
-            Dictionary<string, ItemShop> itemShops = Game1.content.Load<Dictionary<string, ItemShop>>("Mods/ShopTileFramework/ItemShops");
-            Dictionary<string, AnimalShop> animalShops = Game1.content.Load<Dictionary<string, AnimalShop>>("Mods/ShopTileFramework/AnimalShops");
+            Dictionary<string, ItemShop> itemShops = Game1.content.Load<Dictionary<string, ItemShop>>(PathUtilities.NormalizePath("Mods/ShopTileFramework/ItemShops"));
+            Dictionary<string, AnimalShop> animalShops = Game1.content.Load<Dictionary<string, AnimalShop>>(PathUtilities.NormalizePath("Mods/ShopTileFramework/AnimalShops"));
             if (itemShops.Count == 0)
             {
                 ModEntry.monitor.Log($"No shops were found", LogLevel.Debug);

--- a/ShopTileFramework/src/Utility/ConsoleCommands.cs
+++ b/ShopTileFramework/src/Utility/ConsoleCommands.cs
@@ -2,6 +2,7 @@
 using ShopTileFramework.API;
 using ShopTileFramework.Shop;
 using StardewModdingAPI;
+using StardewValley;
 
 namespace ShopTileFramework.Utility
 {
@@ -63,7 +64,7 @@ namespace ShopTileFramework.Utility
                 return;
             }
 
-            Dictionary<string, ItemShop> itemShops = ModEntry.helper.Content.Load<Dictionary<string, ItemShop>>("Mods/ShopTileFramework/ItemShops", ContentSource.GameContent);
+            Dictionary<string, ItemShop> itemShops = Game1.content.Load<Dictionary<string, ItemShop>>("Mods/ShopTileFramework/ItemShops");
             itemShops.TryGetValue(args[0], out ItemShop value);
             if (value == null)
             {
@@ -94,7 +95,7 @@ namespace ShopTileFramework.Utility
                 return;
             }
 
-            Dictionary<string, AnimalShop> animalShops = ModEntry.helper.Content.Load<Dictionary<string, AnimalShop>>("Mods/ShopTileFramework/AnimalShops", ContentSource.GameContent);
+            Dictionary<string, AnimalShop> animalShops = Game1.content.Load<Dictionary<string, AnimalShop>>("Mods/ShopTileFramework/AnimalShops");
             animalShops.TryGetValue(args[0], out AnimalShop value);
             if (value == null)
             {
@@ -125,7 +126,7 @@ namespace ShopTileFramework.Utility
                 return;
             }
 
-            Dictionary<string, ItemShop> itemShops = ModEntry.helper.Content.Load<Dictionary<string, ItemShop>>("Mods/ShopTileFramework/ItemShops", ContentSource.GameContent);
+            Dictionary<string, ItemShop> itemShops = Game1.content.Load<Dictionary<string, ItemShop>>("Mods/ShopTileFramework/ItemShops");
             itemShops.TryGetValue(args[0], out ItemShop shop);
             if (shop == null)
             {
@@ -147,8 +148,8 @@ namespace ShopTileFramework.Utility
         /// </summary>
         private void ListAllShops(string command, string[] args)
         {
-            Dictionary<string, ItemShop> itemShops = ModEntry.helper.Content.Load<Dictionary<string, ItemShop>>("Mods/ShopTileFramework/ItemShops", ContentSource.GameContent);
-            Dictionary<string, AnimalShop> animalShops = ModEntry.helper.Content.Load<Dictionary<string, AnimalShop>>("Mods/ShopTileFramework/AnimalShops", ContentSource.GameContent);
+            Dictionary<string, ItemShop> itemShops = Game1.content.Load<Dictionary<string, ItemShop>>("Mods/ShopTileFramework/ItemShops");
+            Dictionary<string, AnimalShop> animalShops = Game1.content.Load<Dictionary<string, AnimalShop>>("Mods/ShopTileFramework/AnimalShops");
             if (itemShops.Count == 0)
             {
                 ModEntry.monitor.Log($"No shops were found", LogLevel.Debug);


### PR DESCRIPTION
Submitting this initial PR for your review. I'll continue to do more testing, but this should be compliant with existing content packs.

One assumption this makes is that between days ItemShops, AnimalShops, and VanillaShops are stateless.

If something does patch shop data (one example given was to scale difficultly based on stats or even have a discount multiplier perk) then shop assets will be invalidated and reloaded.