### PR TITLE
Suppress train arrival message during event

### DIFF
--- a/TrainStation/ModEntry.cs
+++ b/TrainStation/ModEntry.cs
@@ -366,6 +366,7 @@ namespace TrainStation
         }
         string destinationMessage;
         ICue cue;
+        GameLocation destination;
 
         private void AttemptToWarpBoat(BoatStop stop)
         {
@@ -385,6 +386,7 @@ namespace TrainStation
                 return;
             }
             LocationRequest request = Game1.getLocationRequest(stop.TargetMapName);
+            this.destination = request.Location;
             request.OnWarp += this.Request_OnWarp;
             this.destinationMessage = this.Helper.Translation.Get("ArrivalMessage", new { DestinationName = stop.TranslatedName });
 
@@ -399,7 +401,9 @@ namespace TrainStation
 
         private void Request_OnWarp()
         {
-            Game1.pauseThenMessage(3000, this.destinationMessage);
+            if (this.destination.currentEvent == null)
+                Game1.pauseThenMessage(3000, this.destinationMessage);
+
             this.finishedTrainWarp = true;
         }
 

--- a/TrainStation/ModEntry.cs
+++ b/TrainStation/ModEntry.cs
@@ -366,7 +366,6 @@ namespace TrainStation
         }
         string destinationMessage;
         ICue cue;
-        GameLocation destination;
 
         private void AttemptToWarpBoat(BoatStop stop)
         {
@@ -386,7 +385,6 @@ namespace TrainStation
                 return;
             }
             LocationRequest request = Game1.getLocationRequest(stop.TargetMapName);
-            this.destination = request.Location;
             request.OnWarp += this.Request_OnWarp;
             this.destinationMessage = this.Helper.Translation.Get("ArrivalMessage", new { DestinationName = stop.TranslatedName });
 
@@ -401,7 +399,7 @@ namespace TrainStation
 
         private void Request_OnWarp()
         {
-            if (this.destination.currentEvent == null)
+            if (Game1.currentLocation?.currentEvent is null)
                 Game1.pauseThenMessage(3000, this.destinationMessage);
 
             this.finishedTrainWarp = true;


### PR DESCRIPTION
By request of Lumisteria (aka Lumina), who is a prominent Content Patcher pack creator, I wrote and tested a very small fix here that checks whether an event is going on in the target area between warping and showing the arrival message. It appears to work well and I don't foresee how it would create any issues/unexpected changes. Let me know if you have any questions! Thanks for this cool mod. :)

P.S. Accidentally created a pull request to myself, then just accepted it, lol. Sorry for the two commits! ;)