### PR TITLE
Check if the crop was actually harvested before spawning additional items

### DIFF
--- a/MultiYieldCrops/Framework/HarvestPatches.cs
+++ b/MultiYieldCrops/Framework/HarvestPatches.cs
@@ -19,20 +19,19 @@ namespace MultiYieldCrops.Framework
 
         public static void CropHarvest_prefix(Crop __instance, out bool __state)
         {
-            //checks if crop can be harvested
-            __state = ((int)__instance.currentPhase >= __instance.phaseDays.Count - 1 && (!__instance.fullyGrown || (int)__instance.dayOfCurrentPhase <= 0));
+            __state = CanHarvest(__instance);
         }
 
-        public static void CropHarvest_postfix(int xTile, int yTile, HoeDirt soil, JunimoHarvester junimoHarvester,
-            Crop __instance, bool __state, ref bool __result)
+        public static void CropHarvest_postfix(int xTile, int yTile, HoeDirt soil, JunimoHarvester junimoHarvester, Crop __instance, bool __state, ref bool __result)
         {
+            // wasn't marked harvestable
             if (!__state)
                 return;
 
-            // For single-yield crops, the vanilla function will return true.
-            // For multi-yeidl crops, the vanilla function will reset the instance.
-            // If neither of these are true, the crop didn't get harvested (likely because the player's inventory was full)
-            if ((!__result && __instance.currentPhase.Value >= __instance.phaseDays.Count - 1 && (!__instance.fullyGrown.Value || __instance.dayOfCurrentPhase.Value <= 0)))
+            // The vanilla function will either return true (for single-yield crops) or reset the instance (for
+            // multi-yield crops). If neither is true, the crop didn't get harvested (e.g. because the player's
+            // inventory was full).
+            if (!__result && CanHarvest(__instance))
                 return;
 
             try
@@ -50,13 +49,13 @@ namespace MultiYieldCrops.Framework
             }
         }
 
-        //public static void BushPerformUseAction_postfix(Vector2 tileLocation, Bush __instance)
-        //{
-        //    //not implemented yet
-        //    if ( __instance.inBloom(Game1.currentSeason, Game1.dayOfMonth) && __instance.size.Value == Bush.greenTeaBush)
-        //    {
-        //        ModEntry.instance.SpawnHarvest(tileLocation, "Tea Leaves", HoeDirt.noFertilizer);
-        //    }
-        //}
+        /// <summary>Get whether a crop can be harvested now.</summary>
+        /// <param name="crop">The crop to check.</param>
+        private static bool CanHarvest(Crop crop)
+        {
+            return
+                crop.currentPhase.Value >= crop.phaseDays.Count - 1
+                && (!crop.fullyGrown.Value || crop.dayOfCurrentPhase.Value <= 0);
+        }
     }
 }

--- a/MultiYieldCrops/Framework/HarvestPatches.cs
+++ b/MultiYieldCrops/Framework/HarvestPatches.cs
@@ -24,9 +24,15 @@ namespace MultiYieldCrops.Framework
         }
 
         public static void CropHarvest_postfix(int xTile, int yTile, HoeDirt soil, JunimoHarvester junimoHarvester,
-            Crop __instance, bool __state)
+            Crop __instance, bool __state, ref bool __result)
         {
             if (!__state)
+                return;
+
+            // For single-yield crops, the vanilla function will return true.
+            // For multi-yeidl crops, the vanilla function will reset the instance.
+            // If neither of these are true, the crop didn't get harvested (likely because the player's inventory was full)
+            if ((!__result && __instance.currentPhase.Value >= __instance.phaseDays.Count - 1 && (!__instance.fullyGrown.Value || __instance.dayOfCurrentPhase.Value <= 0)))
                 return;
 
             try


### PR DESCRIPTION
Previously, prefix would only check if the crop was **harvestable**. If the crop was harvestable but the player couldn't actually harvest the crop (because their inventory was full), the postfix would spawn MultiYieldCrops' crops even though the main crop wasn't harvested. You could just stand there with a full inventory over a grown MultiYieldCrop crop, hold right click, and get a bunch of stuff.

This adds a check into the postfix to make sure that the crop was actually harvested.

(It also updates MultiYieldCrops to NET 5.0/SMAPI 3.14.0/Harmony2)