### PR TITLE
Upgrade Empty Cabins - Fixes for Stardew Valley 1.6

### DIFF
--- a/UpgradeEmptyCabins/ModEntry.cs
+++ b/UpgradeEmptyCabins/ModEntry.cs
@@ -71,7 +71,6 @@ namespace UpgradeEmptyCabins
                     continue;
                 this.Monitor.Log("Cabin: " + cab.GetIndoorsName(), LogLevel.Info);
                 this.Monitor.Log("    Upgrade Level: " + ((Cabin)cab.indoors.Value).upgradeLevel, LogLevel.Info);
-                
             }
         }
 
@@ -93,7 +92,7 @@ namespace UpgradeEmptyCabins
                 {
                     var mail = ((Cabin)cab.indoors.Value).owner.mailReceived;
                     this.Monitor.Log("Cabin: " + cab.GetIndoorsName(), LogLevel.Info);
-                    
+
                     if (reno == "renovation_diningroomwall_open")
                     {
                         if (!mail.Contains("renovation_dining_open"))
@@ -170,8 +169,8 @@ namespace UpgradeEmptyCabins
                         else
                             mail.Add(reno);
                     }
-                        
                 }
+
                 ((Cabin)cab.indoors.Value).cribStyle.Set(0);
                 this.Monitor.Log("    cribStyle:  " + ((Cabin)cab.indoors.Value).cribStyle.Value, LogLevel.Info);
                 this.Monitor.Log("    flags: " + mail, LogLevel.Info);
@@ -382,7 +381,7 @@ namespace UpgradeEmptyCabins
                         Game1.drawObjectDialogue(Game1.content.LoadString("Strings\\UI:NotEnoughMoney3"));
                         break;
                     }
-                    Game1.drawObjectDialogue(Game1.content.LoadString("Strings\\Locations:ScienceHouse_Carpenter_NotEnoughWood2", "100")); //TODO String says {0} hardwood.
+                    Game1.drawObjectDialogue(Game1.content.LoadString("Strings\\Locations:ScienceHouse_Carpenter_NotEnoughWood2", "100"));
                     break;
                 case 2:
                     if (Game1.player.Money >= 100000)

--- a/UpgradeEmptyCabins/i18n/default.json
+++ b/UpgradeEmptyCabins/i18n/default.json
@@ -1,7 +1,7 @@
 ﻿{
     "robin.whichcabin_question": "Which Cabin would you like to upgrade?",
     "robin.hu1_materials": "Kitchen upgrade: 10,000g and 450 pieces of wood",
-    "robin.hu2_materials": "Nursery upgrade: 50,000g and 150 pieces of hardwood",
+    "robin.hu2_materials": "Nursery upgrade: 65,000g and 100 pieces of hardwood",
     "robin.hu3_materials": "Cellar upgrade: 100,000g",
     "robin.busy": "Robin is currently working on another building. Come back later.",
     "menu.cancel_option": "Nevermind."

--- a/UpgradeEmptyCabins/i18n/es.json
+++ b/UpgradeEmptyCabins/i18n/es.json
@@ -1,7 +1,7 @@
 ﻿{
     "robin.whichcabin_question": "¿Qué Cabina le gustaría actualizar?",
     "robin.hu1_materials": "Actualización de Cocina: 10,000 gy 450 piezas de madera",
-    "robin.hu2_materials": "Actualización de Guardería: 50,000 gy 150 piezas de madera dura",
+    "robin.hu2_materials": "Actualización de Guardería: 65,000 gy 100 piezas de madera dura",
     "robin.hu3_materials": "Actualización de la Bodega: 100,000g",
     "robin.busy": "Robin está trabajando actualmente en otro edificio. Vuelve mas tarde.",
     "menu.cancel_option": "No importa."

--- a/UpgradeEmptyCabins/i18n/fr.json
+++ b/UpgradeEmptyCabins/i18n/fr.json
@@ -1,7 +1,7 @@
 ﻿{
     "robin.whichcabin_question": "Quelle Cabine souhaitez-vous mettre à niveau?",
     "robin.hu1_materials": "Amélioration de la Cuisine: 10 000 g et 450 morceaux de bois",
-    "robin.hu2_materials": "Amélioration de la Pépinière: 50 000 g et 150 morceaux de bois dur",
+    "robin.hu2_materials": "Amélioration de la Pépinière: 65 000 g et 100 morceaux de bois dur",
     "robin.hu3_materials": "Amélioration de la Cave: 100 000 g",
     "robin.busy": "Robin travaille actuellement sur un autre bâtiment. Revenez plus tard.",
     "menu.cancel_option": "Peu importe."

--- a/UpgradeEmptyCabins/i18n/it.json
+++ b/UpgradeEmptyCabins/i18n/it.json
@@ -1,7 +1,7 @@
 ﻿{
     "robin.whichcabin_question": "Quale Cabina desideri aggiornare?",
     "robin.hu1_materials": "Upgrade della Cucina: 10.000 ge 450 pezzi di legno",
-    "robin.hu2_materials": "Upgrade dell'Asilo Nido: 50.000 ge 150 pezzi di legno duro",
+    "robin.hu2_materials": "Upgrade dell'Asilo Nido: 65.000 ge 100 pezzi di legno duro",
     "robin.hu3_materials": "Aggiornamento dell Scantinato: 100.000 g",
     "robin.busy": "Robin sta attualmente lavorando su un altro edificio. Torna più tardi.",
     "menu.cancel_option": "Non importa."

--- a/UpgradeEmptyCabins/i18n/ko.json
+++ b/UpgradeEmptyCabins/i18n/ko.json
@@ -1,7 +1,7 @@
 ﻿{
     "robin.whichcabin_question": "어떤 오두막을 업그레이드 하시겠습니까?",
     "robin.hu1_materials": "주방 업그레이드 : 10,000 골드, 나무 450개",
-    "robin.hu2_materials": "아이방 업그레이드: 50,000 골드, 단단한 나무 150개",
+    "robin.hu2_materials": "아이방 업그레이드: 65,000 골드, 단단한 나무 100개",
     "robin.hu3_materials": "지하실 업그레이드 : 100,000 골드",
     "robin.busy": "로빈은 현재 다른 건물에서 일하고 있습니다. 나중에 다시 오세요.",
     "menu.cancel_option": "그만하기."

--- a/UpgradeEmptyCabins/i18n/pt.json
+++ b/UpgradeEmptyCabins/i18n/pt.json
@@ -1,7 +1,7 @@
 ﻿{
     "robin.whichcabin_question": "Qual Cabana você gostaria de atualizar?",
     "robin.hu1_materials": "Atualização da Cozinha: 10.000 g e 450 pedaços de madeira",
-    "robin.hu2_materials": "Atualização do Berçário: 50.000 ge 150 peças de madeira",
+    "robin.hu2_materials": "Atualização do Berçário: 65.000 ge 100 peças de madeira",
     "robin.hu3_materials": "Atualização da Adega: 100.000g",
     "robin.busy": "Robin está atualmente trabalhando em outro prédio. Volte mais tarde.",
     "menu.cancel_option": "Deixa pra lá."


### PR DESCRIPTION
Changelog:

- Updated toggle_renovate command to work with 1.6 renovations. toggle_renovate will now appropriately remove or add prerequisite renovations such as the Corner renovation for the Expanded Corner. #92 
- Fixed bug where furniture was not moving correctly when upgrading cabin. 
- Fixed bug where dialogue confirmations were not working. #93 
- Changed hardwood for second cabin upgrade from 150 to 100 to match values in Stardew Valley 1.6. 
- Changed gold for second cabin upgrade from 50,000 to 65,000 to match values in Stardew Valley 1.6. 
- Added list_cabins command to list out the cabin values for toggle_renovate. 
- Added list_renovations command to list possible renovations for toggle_renovate. 
- renovate_cabins command now adds all renovations to all cabins that are level 2 or higher, including removing walls. #92 


