### PR TITLE
Update Tool Upgrade Costs for Stardew Valley 1.6.9

### DIFF
--- a/ToolUpgradeCosts/ModEntry.cs
+++ b/ToolUpgradeCosts/ModEntry.cs
@@ -56,7 +56,6 @@ namespace ToolUpgradeCosts;
             }
         }
 
-
         public static void ShopBuilder_GetShopStock_Postfix(string shopId, ref Dictionary<ISalable, ItemStockInformation> __result)
         {
             if (shopId != Game1.shop_blacksmithUpgrades)
@@ -67,7 +66,7 @@ namespace ToolUpgradeCosts;
                 Dictionary<ISalable, ItemStockInformation> editedStock = new Dictionary<ISalable, ItemStockInformation>();
                 foreach ((ISalable item, ItemStockInformation stockInfo) in __result)
                 {
-                    if (item is Tool tool && Enum.IsDefined(typeof(UpgradeMaterials), tool.UpgradeLevel))
+                    if (item is Tool tool && Enum.IsDefined(typeof(UpgradeMaterials), tool.UpgradeLevel) && stockInfo is not null)
                     {
                         UpgradeMaterials upgradeLevel = (UpgradeMaterials)tool.UpgradeLevel;
                         if (tool is GenericTool)
@@ -78,13 +77,12 @@ namespace ToolUpgradeCosts;
                             price: _instance._config.UpgradeCosts[upgradeLevel].Cost,
                             tradeItemCount: _instance._config.UpgradeCosts[upgradeLevel].MaterialStack,
                             tradeItem: _instance._config.UpgradeCosts[upgradeLevel].MaterialId,
-                            stock: (int)(stockInfo?.Stock),
-                            stockMode: stockInfo?.LimitedStockMode ?? LimitedStockMode.None,
-                            itemToSyncStack: stockInfo?.ItemToSyncStack ?? tool,
-                            stackDrawType: stockInfo?.StackDrawType,
-                            actionsOnPurchase: stockInfo?.ActionsOnPurchase ?? new List<string>()
+                            stock: stockInfo.Stock,
+                            stockMode: stockInfo.LimitedStockMode,
+                            itemToSyncStack: stockInfo.ItemToSyncStack,
+                            stackDrawType: stockInfo.StackDrawType,
+                            actionsOnPurchase: stockInfo.ActionsOnPurchase
                         );
-
                     }
                     else
                     {

--- a/ToolUpgradeCosts/ModEntry.cs
+++ b/ToolUpgradeCosts/ModEntry.cs
@@ -10,8 +10,8 @@ using StardewValley.Internal;
 using StardewValley.Tools;
 using ToolUpgradeCosts.Framework;
 
-namespace ToolUpgradeCosts
-{
+namespace ToolUpgradeCosts;
+
     public class ModEntry : Mod
     {
         private static ModEntry _instance;
@@ -56,6 +56,7 @@ namespace ToolUpgradeCosts
             }
         }
 
+
         public static void ShopBuilder_GetShopStock_Postfix(string shopId, ref Dictionary<ISalable, ItemStockInformation> __result)
         {
             if (shopId != Game1.shop_blacksmithUpgrades)
@@ -73,12 +74,17 @@ namespace ToolUpgradeCosts
                         {
                             upgradeLevel++;
                         }
-                        editedStock[tool] = stockInfo with
-                        {
-                            Price = _instance._config.UpgradeCosts[upgradeLevel].Cost,
-                            TradeItem = _instance._config.UpgradeCosts[upgradeLevel].MaterialId,
-                            TradeItemCount = _instance._config.UpgradeCosts[upgradeLevel].MaterialStack
-                        };
+                        editedStock[tool] = new ItemStockInformation(
+                            price: _instance._config.UpgradeCosts[upgradeLevel].Cost,
+                            tradeItemCount: _instance._config.UpgradeCosts[upgradeLevel].MaterialStack,
+                            tradeItem: _instance._config.UpgradeCosts[upgradeLevel].MaterialId,
+                            stock: (int)(stockInfo?.Stock),
+                            stockMode: stockInfo?.LimitedStockMode ?? LimitedStockMode.None,
+                            itemToSyncStack: stockInfo?.ItemToSyncStack ?? tool,
+                            stackDrawType: stockInfo?.StackDrawType,
+                            actionsOnPurchase: stockInfo?.ActionsOnPurchase ?? new List<string>()
+                        );
+
                     }
                     else
                     {
@@ -93,4 +99,3 @@ namespace ToolUpgradeCosts
             }
         }
     }
-}


### PR DESCRIPTION
Changes to make the mod work in version tested "v1.6.15 build 24356", this should be enough for the mod to work normally again.